### PR TITLE
add fixes for memory issues to powermodeling branch

### DIFF
--- a/src/sunneed_listener.c
+++ b/src/sunneed_listener.c
@@ -202,7 +202,7 @@ serve_open_file(
         }
         
         // TODO Free this
-        sub_resp->path = malloc(strlen(dummypath));
+        sub_resp->path = malloc(strlen(dummypath) + 1);
         strncpy(sub_resp->path, dummypath, strlen(dummypath) + 1);
     } else {
         // They requested a non-dummy file.

--- a/src/sunneed_power.c
+++ b/src/sunneed_power.c
@@ -72,6 +72,7 @@ sunneed_quantum_begin(void) {
         LOG_E("Failed to allocate space for power usage events!");
         return 1;
     }
+    power_usage_evs->next = NULL;
 
     LOG_I("Started quantum %d", current_quantum.id);
     current_quantum.is_active = true;
@@ -131,6 +132,7 @@ sunneed_quantum_end(void) {
 sunneed_worker_thread_result_t
 sunneed_quantum_worker(__attribute__((unused)) void *args) {
     int ret;
+    power_usage_evs = NULL;
     while (true) {
         if ((ret = sunneed_quantum_begin()) != 0) {
             goto end;


### PR DESCRIPTION
power_usage_evs struct's next ptr was not set to NULL after being malloc'd, so free() was called on power_usage_evs->next while it was set to garbage val
in sunneed_listener.c/serve_open_file() -- sub_resp->path was malloc'd to strlen(dummypath) instead of (strlen(dummypath)+1)